### PR TITLE
feat: remove init asset packs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,4 @@
-import {
-  Animator,
-  AudioSource,
-  AvatarAttach,
-  engine,
-  GltfContainer,
-  Material,
-  pointerEventsSystem,
-  Transform,
-  VideoPlayer,
-  VisibilityComponent
-} from '@dcl/sdk/ecs'
-import { initAssetPacks } from '@dcl/asset-packs/dist/scene-entrypoint'
 import {} from '@dcl/sdk/math'
-
-initAssetPacks(engine, pointerEventsSystem, {
-  Animator,
-  AudioSource,
-  AvatarAttach,
-  Transform,
-  VisibilityComponent,
-  GltfContainer,
-  Material,
-  VideoPlayer
-})
+import { engine } from '@dcl/sdk/ecs'
 
 export function main() {}


### PR DESCRIPTION
Remove `initAssetPacks` related code since it's not necessary anymore from v7.4.9 of the SDK